### PR TITLE
Allow custom mappings to be loaded; clean up JDK 11 compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ __NOTE-4:__ This fixes a bug that only occurs when running in the non-interactiv
 
 __NOTE-5:__ The v1.9.0.1 release is a patch providing support for Avails 2.5.2
 
+__NOTE-6:__ The columns in an Excel output file are now ordered alphabetically.
+
 ## <a name="h_Overview">2) Overview:</a>
 
 This repository contains Java software supporting the creation and usage of MDDF files including
@@ -139,6 +141,8 @@ Prior to July 2017 and the release of v1.3 of the mddf-lib, the native executabl
 independent of the mddf-lib version. 
 
 ## <a name="h_building">5) Using mddf-lib:</a>
+### <a name="h_building_maven">5.1) Accessing via Maven</a>
+
 The mddf-tools described in the next section are implemented on top of mddf-lib. Starting with v1.5.1, releases of mddf-lib are 
 available via the [Maven Central Repository](https://search.maven.org/search?q=a:mddf-lib). Developers wishing to use mddf-lib in their own 
 software therefore have two options: building from the source or adding a dependency to their build scripts, e.g.:
@@ -148,6 +152,16 @@ software therefore have two options: building from the source or adding a depend
 			<artifactId>mddf-lib</artifactId>
 			<version>${mddf.lib.version}</version>
 		</dependency>
+
+### <a name="h_building_custom">5.2) Using custom column mappings (Excel only)</a>
+
+When converting from XML to Excel, it's possible to provide a custom mappings file by setting the `mddf.mappings.path` system property prior to execution.  The default file is located [here](mddf-lib/src/com/movielabs/mddflib/avails/xlsx/Mappings.json).
+
+Custom mappings can be used if you intend to use some of the free-form fields in the spec. You can also use them to provide an ordering for columns in the output file, by adding a numeric prefix to the column index.  For example, to ensure that the `Avail/DisplayName` column is always first in the output, you could use a mapping like the following:
+
+`"01:Avail:DisplayName": "{avail}Licensor/{md}DisplayName"`
+
+The default ordering, if no numeric prefix is provided, is alphabetical.
 
 
 ## <a name="h_Install">6) Installing and Running mddf-tools:</a>

--- a/mddf-lib/src/com/movielabs/mddflib/logging/LogEntryFolder.java
+++ b/mddf-lib/src/com/movielabs/mddflib/logging/LogEntryFolder.java
@@ -27,6 +27,7 @@ import java.util.Enumeration;
 import java.util.List;
 
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import org.jdom2.Document;
 import com.movielabs.mddf.MddfContext.FILE_FMT;
@@ -142,9 +143,9 @@ public class LogEntryFolder extends LogEntry {
 	}
 
 	public DefaultMutableTreeNode getChild(String id) {
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		while (kinder.hasMoreElements()) {
-			LogEntry nextNode = kinder.nextElement();
+			LogEntry nextNode = (LogEntry) kinder.nextElement();
 			if (nextNode.getTagAsText().equals(id)) {
 				return (nextNode);
 			}
@@ -157,7 +158,7 @@ public class LogEntryFolder extends LogEntry {
 	 */
 	public int getMsgCnt() {
 		int msgCnt = msgList.size();
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		while (kinder.hasMoreElements()) {
 			LogEntryFolder nextChild = (LogEntryFolder) kinder.nextElement();
 			msgCnt = msgCnt + nextChild.getMsgCnt();
@@ -172,7 +173,7 @@ public class LogEntryFolder extends LogEntry {
 	public List<LogEntryNode> getMsgList() {
 		List<LogEntryNode> fullList = new ArrayList<LogEntryNode>();
 		fullList.addAll(msgList);
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		while (kinder.hasMoreElements()) {
 			LogEntryFolder nextChild = (LogEntryFolder) kinder.nextElement();
 			fullList.addAll(nextChild.getMsgList());
@@ -189,7 +190,7 @@ public class LogEntryFolder extends LogEntry {
 	 */
 	public boolean hasErrorsMsgs(boolean forErrors) {
 		/* is this a 'leaf' folder or intermediate? */
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		if (kinder.hasMoreElements()) {
 			boolean isErrFolder = this.getTagAsText().equals(LogMgmt.logLevels[LogMgmt.LEV_ERR]);
 			while (kinder.hasMoreElements()) {
@@ -221,7 +222,7 @@ public class LogEntryFolder extends LogEntry {
 	public int getHighestLevel() {
 		int highest = -1;
 		/* is this a 'leaf' folder or intermediate? */
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		if (kinder.hasMoreElements()) {
 			LogEntryFolder infoFolder = null;
 			while (kinder.hasMoreElements()) {
@@ -248,7 +249,7 @@ public class LogEntryFolder extends LogEntry {
 	 */
 	public void deleteMsgs() {
 		msgList = new ArrayList<LogEntryNode>();
-		Enumeration<LogEntry> kinder = this.children();
+		Enumeration<TreeNode> kinder = this.children();
 		while (kinder.hasMoreElements()) {
 			LogEntryFolder nextChild = (LogEntryFolder) kinder.nextElement();
 			nextChild.deleteMsgs();

--- a/mddf-lib/src/com/movielabs/mddflib/manifest/validation/CpeValidator.java
+++ b/mddf-lib/src/com/movielabs/mddflib/manifest/validation/CpeValidator.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -90,8 +91,13 @@ public class CpeValidator extends ManifestValidator implements ProfileValidator 
 		}
 
 		public List<ExperienceNode> getChildren() {
-			Enumeration<ExperienceNode> kinder = this.children();
-			return Collections.list(kinder);
+			Enumeration<TreeNode> kinder = this.children();
+			List<ExperienceNode> result = new ArrayList<ExperienceNode>();
+			while (kinder.hasMoreElements()) {
+				result.add((ExperienceNode) kinder.nextElement());
+			}
+
+			return result;
 		}
 
 		public List<ExperienceNode> getDescendents() {
@@ -329,8 +335,9 @@ public class CpeValidator extends ManifestValidator implements ProfileValidator 
 	 */
 	protected void validateModel(DefaultTreeModel infoModel) {
 		ExperienceNode modelRoot = (ExperienceNode) infoModel.getRoot();
-		Enumeration<ExperienceNode> kinder = modelRoot.children();
-		for (ExperienceNode topNode : Collections.list(kinder)) {
+		Enumeration<TreeNode> kinder = modelRoot.children();
+		while (kinder.hasMoreElements()) {
+			ExperienceNode topNode = (ExperienceNode) kinder.nextElement();
 			validateTopMetadata(topNode);
 			List<ExperienceNode> descendants = topNode.getDescendents();
 			for (ExperienceNode lowerNode : descendants) {
@@ -470,7 +477,7 @@ public class CpeValidator extends ManifestValidator implements ProfileValidator 
 	 * Expand hierarchical structure of Experience Elements by recursively
 	 * descending and adding all <tt>ExperienceChild</tt> elements found.
 	 * 
-	 * @param nextExpNode
+	 * @param curExpNode
 	 */
 	private void addChildExperiences(ExperienceNode curExpNode) {
 		Element curExpEl = curExpNode.getExpEl();

--- a/mddf-tools/src/com/movielabs/mddf/tools/ToolLauncher.java
+++ b/mddf-tools/src/com/movielabs/mddf/tools/ToolLauncher.java
@@ -185,7 +185,7 @@ public class ToolLauncher {
 			} else {
 				Set<String> allowed = new HashSet<String>();
 				allowed.addAll(Arrays.asList(MddfContext.getSupportedVersions("AVAIL")));
-				allowed.addAll(Arrays.asList(MddfContext.getSupportedVersions("AVAIL-E")));
+				allowed.addAll(Arrays.asList(MddfContext.getSupportedVersions("AVAIL_E")));
 				for (String fmt : xlatFmts) {
 					fmt = fmt.replaceAll(",", "");
 					if (allowed.contains(fmt)) {


### PR DESCRIPTION
This change would cause the columns in an Excel output to be ordered (by default, alphabetically by key).  It also allows a client to override the mappings file with their own custom file, and provides a mechanism for providing a column order by adding a numeric prefix to the key.  I need this functionality because we are looking to produce a document for a business user to inspect, and they're used to a file where things are organized in a certain way (display name, alias, start date, end date, etc.)

I also made some minor changes to clean up compilation errors on newer versions of Java.  (The current version does not compile when using JDK 11+, even when targeting Java 8).

Finally, I fixed an issue that I found when trying to do an Excel output from the command line -- the `AVAIL_E` constant was wrong when looking up the valid Excel output versions.

I did not add any new tests, because I felt that the existing Excel output tests did a satisfactory job.

This particular approach to ordering was suggested by @ljlevin in email.